### PR TITLE
update blockstack.js to 18.2.1

### DIFF
--- a/BlockUSign.Ionic/package-lock.json
+++ b/BlockUSign.Ionic/package-lock.json
@@ -1852,6 +1852,18 @@
         }
       }
     },
+    "bip39": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.5.0.tgz",
+      "integrity": "sha512-xwIx/8JKoT2+IPJpFEfXoWdYwP7UVAoUxxLNfGCfVowaJE7yg1Y5B1BVPqlUNsBq5/nGwmFkwRJ8xDW4sX8OdA==",
+      "requires": {
+        "create-hash": "^1.1.0",
+        "pbkdf2": "^3.0.9",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "unorm": "^1.3.3"
+      }
+    },
     "bip66": {
       "version": "1.1.5",
       "resolved": "https://dow-vsts.pkgs.visualstudio.com/_packaging/CDMC-Code-Share/npm/registry/bip66/-/bip66-1.1.5.tgz",
@@ -2142,12 +2154,15 @@
       }
     },
     "blockstack": {
-      "version": "18.0.4",
-      "resolved": "https://registry.npmjs.org/blockstack/-/blockstack-18.0.4.tgz",
-      "integrity": "sha512-LiWMvdhG8jmyzNeX55wnMEFWzJmn9ZqY5ic81INj+OJw3FF7Aoj2+/acEUTEc0ZkvZPHskTTBBVU9wwHsV2QSA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/blockstack/-/blockstack-18.2.1.tgz",
+      "integrity": "sha512-hcJdNhltNSRZg6iouSauWOzKpVnfC1NFIMBhC9sZjaIFCPIojDrgvRcgoh3AEy8LMkj1krr26AKAOhnRcQJmng==",
       "requires": {
         "ajv": "^4.11.5",
+        "babel-runtime": "^6.26.0",
         "bigi": "^1.4.2",
+        "bip32": "^1.0.2",
+        "bip39": "^2.5.0",
         "bitcoinjs-lib": "^4",
         "cheerio": "^0.22.0",
         "cross-fetch": "^2.2.2",
@@ -2163,6 +2178,7 @@
         "ripemd160": "^2.0.1",
         "schema-inspector": "^1.6.4",
         "sprintf-js": "^1.0.3",
+        "triplesec": "^3.0.26",
         "uuid": "^3.2.1",
         "validator": "^7.0.0",
         "zone-file": "^0.2.2"
@@ -2183,14 +2199,14 @@
           "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
         },
         "base64url": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.0.tgz",
-          "integrity": "sha512-LIVmqIrIWuiqTvn4RzcrwCOuHo2DD6tKmKBPXXlr4p4n4l6BZBkwFTIa3zu1XkX5MbZgro4a6BvPi+n2Mns5Gg=="
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+          "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
         },
         "combined-stream": {
-          "version": "1.0.6",
-          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+          "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -2205,37 +2221,47 @@
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
         "form-data": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
           "requires": {
             "asynckit": "^0.4.0",
-            "combined-stream": "1.0.6",
+            "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
           }
         },
         "har-validator": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
           "requires": {
-            "ajv": "^5.3.0",
+            "ajv": "^6.5.5",
             "har-schema": "^2.0.0"
           },
           "dependencies": {
             "ajv": {
-              "version": "5.5.2",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-              "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+              "version": "6.6.2",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+              "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
               "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
+                "fast-deep-equal": "^2.0.1",
                 "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
               }
             }
           }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "jsontokens": {
           "version": "0.7.8",
@@ -2250,14 +2276,19 @@
           }
         },
         "mime-db": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-          "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+          "version": "1.37.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+          "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
         },
         "oauth-sign": {
           "version": "0.9.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
           "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "qs": {
           "version": "6.5.2",
@@ -2292,11 +2323,11 @@
           },
           "dependencies": {
             "mime-types": {
-              "version": "2.1.20",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-              "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+              "version": "2.1.21",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+              "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
               "requires": {
-                "mime-db": "~1.36.0"
+                "mime-db": "~1.37.0"
               }
             }
           }
@@ -2313,6 +2344,21 @@
           "requires": {
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+            }
+          }
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+          "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+          "requires": {
+            "punycode": "^2.1.0"
           }
         },
         "uuid": {
@@ -3287,24 +3333,6 @@
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
-    "compressjs": {
-      "version": "github:openpgpjs/compressjs#bfbb371a34d1750afa34bfa49156461acdab79a9",
-      "from": "github:openpgpjs/compressjs",
-      "requires": {
-        "amdefine": "~1.0.0",
-        "commander": "~2.8.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.8.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
-        }
-      }
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3733,9 +3761,9 @@
       "integrity": "sha1-N0edg8dRMbBnfQBRDQQZ/MzJvJY="
     },
     "cross-fetch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.2.tgz",
-      "integrity": "sha1-pH/09/xxLauo9qaVoRyUhEDUVyM=",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
+      "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
       "requires": {
         "node-fetch": "2.1.2",
         "whatwg-fetch": "2.0.4"
@@ -3743,7 +3771,7 @@
       "dependencies": {
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
         }
       }
@@ -6003,11 +6031,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-    },
     "graphite-docs": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/graphite-docs/-/graphite-docs-0.3.0.tgz",
@@ -6404,6 +6427,24 @@
           "dev": true
         }
       }
+    },
+    "iced-error": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/iced-error/-/iced-error-0.0.13.tgz",
+      "integrity": "sha512-yEEaG8QfyyRL0SsbNNDw3rVgTyqwHFMCuV6jDvD43f/2shmdaFXkqvFLGhDlsYNSolzYHwVLM/CrXt9GygYopA=="
+    },
+    "iced-lock": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iced-lock/-/iced-lock-1.1.0.tgz",
+      "integrity": "sha1-YRbvHKs6zW5rEIk7snumIv0/3nI=",
+      "requires": {
+        "iced-runtime": "^1.0.0"
+      }
+    },
+    "iced-runtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/iced-runtime/-/iced-runtime-1.0.3.tgz",
+      "integrity": "sha1-LU9PuZmreqVDCxk8d6f85BGDGc4="
     },
     "iconv-lite": {
       "version": "0.4.19",
@@ -8052,6 +8093,14 @@
         "moment": ">= 2.9.0"
       }
     },
+    "more-entropy": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/more-entropy/-/more-entropy-0.0.7.tgz",
+      "integrity": "sha1-Z7/G96hvJvvDeqyD/UbYjGHRCbU=",
+      "requires": {
+        "iced-runtime": ">=0.0.1"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -8888,8 +8937,6 @@
         "asn1.js": "^5.0.0",
         "bn.js": "^4.11.8",
         "buffer": "^5.0.8",
-        "compressjs": "github:openpgpjs/compressjs#bfbb371a34d1750afa34bfa49156461acdab79a9",
-        "elliptic": "github:openpgpjs/elliptic#e187e706e11fa51bcd20e46e5119054be4e2a4a6",
         "hash.js": "^1.1.3",
         "node-fetch": "^1.7.3",
         "node-localstorage": "~1.3.0",
@@ -8916,9 +8963,25 @@
             "ieee754": "^1.1.4"
           }
         },
+        "commander": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "compressjs": {
+          "version": "github:openpgpjs/compressjs#bfbb371a34d1750afa34bfa49156461acdab79a9",
+          "from": "github:openpgpjs/compressjs#bfbb371a34d1750afa34bfa49156461acdab79a9",
+          "requires": {
+            "amdefine": "~1.0.0",
+            "commander": "~2.8.1"
+          }
+        },
         "elliptic": {
           "version": "github:openpgpjs/elliptic#e187e706e11fa51bcd20e46e5119054be4e2a4a6",
-          "from": "github:openpgpjs/elliptic",
+          "from": "github:openpgpjs/elliptic#e187e706e11fa51bcd20e46e5119054be4e2a4a6",
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -9360,6 +9423,11 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
     },
     "progress-stream": {
       "version": "1.2.0",
@@ -11629,6 +11697,19 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
+    "triplesec": {
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/triplesec/-/triplesec-3.0.27.tgz",
+      "integrity": "sha512-FDhkxa3JYnPOerOd+8k+SBmm7cb7KkyX+xXwNFV3XV6dsQgHuRvjtbnzWfPJ2kimeR8ErjZfPd/6r7RH6epHDw==",
+      "requires": {
+        "iced-error": ">=0.0.9",
+        "iced-lock": "^1.0.1",
+        "iced-runtime": "^1.0.2",
+        "more-entropy": ">=0.0.7",
+        "progress": "~1.1.2",
+        "uglify-js": "^3.1.9"
+      }
+    },
     "true-case-path": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
@@ -12272,6 +12353,11 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "unorm": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
+      "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/BlockUSign.Ionic/package.json
+++ b/BlockUSign.Ionic/package.json
@@ -56,7 +56,7 @@
     "bitcore-explorers": "^1.0.1",
     "bitcore-lib": "^0.15.0",
     "bitcore-message": "^1.0.4",
-    "blockstack": "^18.0.4",
+    "blockstack": "^18.2.1",
     "blockstack.ts": "^0.1.0",
     "bower": "^1.8.2",
     "browserify": "^16.2.3",


### PR DESCRIPTION
Hey there!

We recently upgraded blockstack.js to gracefully handle failures in the case of Gaia tokens being invalidated. With this upgrade, if Gaia tokens are ever invalidated, `blockstack.js` will automatically generate a new token and retry a write to Gaia.

Without this change, all writes will fail until the user logs out and back in.

I think this upgrade is rather important, so that your app can gracefully handle Gaia authentication errors due to token invalidations.

Hope all is well,

Hank